### PR TITLE
Fix Typebot metadata

### DIFF
--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -1,6 +1,6 @@
 import { configService, S3 } from '@config/env.config';
 
-const getTypeMessage = (msg: any) => {
+export const getTypeMessage = (msg: any) => {
   let mediaId: string;
 
   if (configService.get<S3>('S3').ENABLE) mediaId = msg.message?.mediaUrl;


### PR DESCRIPTION
## Summary
- expose `getTypeMessage` helper
- include `messageType`, `instanceName`, `apiKey`, and `pushName` when sending data to Typebot
- relax request typing to allow these fields

## Testing
- `npx eslint --config .eslintrc.js --ext .ts src` *(fails: A config object is using the "parser" key)*
- `npm test` *(fails: tsnd: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691d9926248332a64bcfb07afca892